### PR TITLE
Weekly Report API Integration Synced backend and env changes to groupD/development

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16264,9 +16264,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -16274,7 +16274,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/server/.env
+++ b/server/.env
@@ -1,4 +1,4 @@
-PORT=5004
+PORT=5000
 MONGO_URI=mongodb+srv://IPMS_USER:SEP_SPRING2025@ipms-cluster.os34l.mongodb.net/IPMS?retryWrites=true&w=majority&appName=IPMS-Cluster
 EMAIL_USER=<your-email>
 EMAIL_PASS=<your-email-password-or-app-specific-password>


### PR DESCRIPTION
Added backend API for weekly report submission
 MongoDB Atlas integration via .env
 Routes: POST /api/weekly-reports, GET /api/weekly-reports/:userId
 Mongoose schema with studentId, task fields, etc.

Tested locally on port 5000. Ready for QA testing 
